### PR TITLE
Support other syntax

### DIFF
--- a/src/max-length-of-title.js
+++ b/src/max-length-of-title.js
@@ -44,8 +44,17 @@ function getMessage(text, limit, lang = 'en') {
 }
 
 function parseHeader(text) {
-  const match = trimLeft(text).match(/^([#]+)([^#]*)$/);
-  const title = trimLeft(match[2]);
-  const level = match[1];
-  return { level, title };
+  const match1 = trimLeft(text).match(/^([#]+)([^#]*)$/);
+  if (match1 !== null) {
+    const title = trimLeft(match1[2]);
+    const level = match1[1];
+    return { level, title };
+  }
+  const match2 = trimLeft(text).match(/^(.*)\n(-+|=+)$/);
+  if (match2 !== null) {
+    const title = trimLeft(match2[1]);
+    const level = match2[2][0] === '=' ? '#' : '##';
+    return { level, title };
+  }
+  throw new Error('Unknown Header.Syntax: ' + text);
 }

--- a/src/max-length-of-title.js
+++ b/src/max-length-of-title.js
@@ -13,9 +13,9 @@ export default function(context, options = {}) {
   return {
     [Syntax.Header](node) {
       return new Promise((resolve, reject) => {
-        const match = trimLeft(getSource(node)).match(/^([#]+)([^#]*)$/);
-        const title = trimLeft(match[2]);
-        const limit = options[match[1]];
+        const match = parseHeader(getSource(node));
+        const title = match.title;
+        const limit = options[match.level];
 
         const length = options.zenkakuBase ? zenkakuBaseLength(title) : title.length;
 
@@ -41,4 +41,11 @@ function getMessage(text, limit, lang = 'en') {
     default:
       return `"${text}" is over ${limit}`;
   }
+}
+
+function parseHeader(text) {
+  const match = trimLeft(text).match(/^([#]+)([^#]*)$/);
+  const title = trimLeft(match[2]);
+  const level = match[1];
+  return { level, title };
 }

--- a/test/max-length-of-title-test.js
+++ b/test/max-length-of-title-test.js
@@ -109,4 +109,43 @@ describe('max-length-of-title', function() {
       }).then(done, done);
     });
   });
+
+  context('when use "===" or "---" syntax (with options)', () => {
+    const textlint = new TextLintCore();
+
+    textlint.setupRules({
+      'max-length-of-title': rule
+    },{
+      'max-length-of-title': {
+        '#': 5,
+        '##': 8
+      }
+    });
+
+    it('should report error', (done) => {
+      textlint.lintMarkdown(`
+title.
+===
+subtitle.
+---
+      `).then(result => {
+
+        assert(result.messages.length === 2);
+
+        }).then(done, done);
+    });
+
+    it('should not report error', (done) => {
+      textlint.lintMarkdown(`
+title
+===
+subtitle
+---
+      `).then(result => {
+
+        assert(result.messages.length === 0);
+
+      }).then(done, done);
+    });
+  });
 });


### PR DESCRIPTION
`const match = trimLeft(getSource(node)).match(/^([#]+)([^#]*)$/);`

`match` is null when using [setext headings](http://spec.commonmark.org/0.27/#setext-headings) .

```
header
===
```

or 

```
header
---
```
